### PR TITLE
Correct README.md command errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ sudo cp linux/setgatewaymac.sh /etc/NetworkManager/dispatcher.d/25-setgatewaymac
 ```
 Give Correct permissions
 ```
-chown root:root /etc/NetworkManager/dispatcher.d/25-setgatewaymac
-sudo chmod +x 733 /etc/NetworkManager/dispatcher.d/25-setgatewaymac
+sudo chown root:root /etc/NetworkManager/dispatcher.d/25-setgatewaymac
+sudo chmod +x /etc/NetworkManager/dispatcher.d/25-setgatewaymac
 ```
 Done
 


### PR DESCRIPTION
The `Linux Installation` section of the README.md file included the following errors: missing sudo for chown, and an incorrect & duplicate mode for chmod.
1) The chown command would fail on most systems because of a missing sudo command prefix, which would prevent chowning the file due to the lack of permissions.
2) An incorrect mode value (733, or rwx-wx-wx, instead of the _presumably_ desired 755) -- which furthermore, would actually be treated as a filename argument (not a mode value) due to the duplicate use of "+x" earlier in the line as the actual mode value to apply.